### PR TITLE
Fix links to this year's shared task page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
     <h3 class='mailing-list-title'>Announcements</h3>
     <ul class=''>
     <li class='mailing-list-announcement-new'><i>2023-06-06:</i>
-    <b>💥 Topics for 2023 have been released!</b> Visit <a href='/2023'>this year's shared task page</a> for information on how to download them from the NIST website.
+    <b>💥 Topics for 2023 have been released!</b> Visit <a href='/2023.md'>this year's shared task page</a> for information on how to download them from the NIST website.
     </li>
-    <li class='mailing-list-announcement-new'><i>2023-05-09:</i> <b>✍️ Guidelines for NeuCLIR 2023 have been finalized</b> and are available at <a href='/2023'>this year's shared task page</a>.</li>
+    <li class='mailing-list-announcement-new'><i>2023-05-09:</i> <b>✍️ Guidelines for NeuCLIR 2023 have been finalized</b> and are available at <a href='/2023.md'>this year's shared task page</a>.</li>
     <li class='mailing-list-announcement-old'><i>2023-04-24:</i> The overview paper for 2022 NeuCLIR at TREC has been <a href='https://arxiv.org/abs/2304.12367'>posted on arXiv</a>. Check it out!</li>
     <li class='mailing-list-announcement-old'><i>2023-02-01:</i> Good news! <b>NeuCLIR 2023 planning has started!</b>.</li>
     <li class='mailing-list-announcement-old'><i>2022-11-18:</i> <b>Thank you for participating to NeuCLIR 2022.</b> This track is now concluded. If you missed the presentation at TREC 2022, you can check out slides <a href='https://docs.google.com/presentation/d/1wuo7zzxS5qRtZfnzsERK3p3Y5KaYVWwyWE-ClvI7hWs/edit#slide=id.p'>here</a>. To share your feedback with NeuCLIR 2022 organizers, use <a href='https://docs.google.com/forms/d/e/1FAIpQLSfgoGQjiZkmwe6hGPZA1jShoLb12SHaeMn4taUZisFZ8VJqWw/viewform'>this Google Form</a>.</li>


### PR DESCRIPTION
The links were missing a `.md`. Perhaps they worked for others but I needed the `.md` to make them work!